### PR TITLE
remove etherscanapi key since not needed to get blocknum

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installing Geth is easy. Running Geth at scale can be a headache. Setting up the
 * Automatic rotation of unhealthy nodes
 * Automatic health checking for syncing state
 * Custom VPC and subnet compatible
-* Bring your own Infura and Etherscan API keys
+* Bring your own Infura API keys
 * Proven instance types that will run Geth in production
 * Hardened Geth node for mass RPC queries
 * AWS best practices for infrastructure and security
@@ -32,9 +32,6 @@ The ARN string for the SSL certificate you want on the load balancer. This is us
 This field is optional.
 
 If you specify this field, port 80 access is automatically disabled for security. You will need to create a Route 53 record pointing to the load balancer with the correct DNS name.
-
-#### Etherscan API Key
-Prior to starting the stack, you need to register for an Etherscan API key. You can [use the instructions listed here](https://etherscan.io/apis) to create an account and get a new API key.
 
 #### Infura API Key
 An optional API key can be provided for Infura. This might result in less rate limiting and better quality of service with Infura when querying their nodes.

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -37,10 +37,6 @@ Parameters:
     - cd5.9xlarge
     - cd5.18xlarge
     ConstraintDescription: must be a valid EC2 instance type.
-  EtherscanAPIKey:
-    Description: 'Etherscan API Key (found here: https://etherscan.io/apis)'
-    ConstraintDescription: must be a valid Etherscan API Key
-    Type: String
   InfuraAPIKey:
     Description: (Optional) Infura API Key
     ConstraintDescription: must be a valid string
@@ -217,7 +213,7 @@ Resources:
                   var _ = require('lodash');
                   var app = express();
 
-                  var etherscan_url = "https://api.etherscan.io/api?module=proxy&action=eth_blockNumber&apikey=${EtherscanAPIKey}";
+                  var etherscan_url = "https://api.etherscan.io/api?module=proxy&action=eth_blockNumber";
                   var infura_url = "https://mainnet.infura.io/${InfuraAPIKey}";
 
                   app.get('/healthcheck', function (req, res) {


### PR DESCRIPTION
Without an API key, a rate limit of 5 requests/seconds is imposed so you may receive a HTTP 403 error if exceed this limit. However given that this health check runs less frequently, siding with easier setup and less keys.